### PR TITLE
Make it possible to have multiple instances per server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,8 +40,10 @@ services:
       - ./nginx.conf.template:/etc/nginx/templates/default.conf.template
     env_file:
       - ./.env
+    environment:
+      - SCRIPT_NAME=${SCRIPT_NAME:-}
     ports:
-      - 80:80
+      - ${REVERSE_PROXY_PORT:-80}:80
     depends_on:
       - web
     restart: unless-stopped

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -14,11 +14,11 @@ server {
         proxy_redirect off;
     }
 
-    location /static/ {
+    location ${SCRIPT_NAME}/static/ {
         alias /app/staticfiles/;
     }
 
-    location /media/ {
+    location ${SCRIPT_NAME}/media/ {
         alias /app/writable/media/;
     }
 }

--- a/src/lm_project/settings.py
+++ b/src/lm_project/settings.py
@@ -35,6 +35,10 @@ DEBUG = env.bool('DEBUG', False)
 ALLOWED_HOSTS = env.list('ALLOWED_HOSTS')
 CSRF_TRUSTED_ORIGINS = env.list('CSRF_TRUSTED_ORIGINS')
 
+INTERNAL_IPS = ["127.0.0.1",]
+
+SCRIPT_NAME = env('SCRIPT_NAME', "")
+
 LANGUAGES = [
     ("en", _("English")),
     ("nl", _("Dutch")),
@@ -122,6 +126,7 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+LOGIN_REDIRECT_URL = "/" if not SCRIPT_NAME else SCRIPT_NAME
 
 # Internationalization
 # https://docs.djangoproject.com/en/5.2/topics/i18n/
@@ -138,7 +143,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.2/howto/static-files/
 
-STATIC_URL = 'static/'
+STATIC_URL = 'static/' if not SCRIPT_NAME else f'{SCRIPT_NAME}/static/'
 
 STATICFILES_DIRS = [
     os.path.join(BASE_DIR, "static"),


### PR DESCRIPTION
_This PR makes it possible to have multiple instances on a single server. It gives the possibility to let the client test multiple new features in parallel. Explanation below._

# Multiple instances on same server

## Start a new instance

Copy `.env` from another instance, and get `docker-compose.yml` and `nginx.conf.template` from this repo. Then:

1. Change/add SCRIPT_NAME and REVERSE_PROXY_PORT in `.env` to e.g. `/foo` and `8001`
2. Start with `docker compose -p <instance-name> up -d`
3. Migrate: `docker compose -p <instance-name> python manage.py migrate`
4. Collect static: `docker compose -p <instance-name> python manage.py collectstatic`

## Start the main reverse proxy

In a separate directory, create the following files.

**docker-compose.yml**:

```
services:
  nginx:
    image: nginx:latest
    volumes:
      - ./nginx.conf.template:/etc/nginx/templates/default.conf.template
    ports:
      - 80:80
    restart: unless-stopped
```

**nginx.conf.template**:

```
server {
    listen 80;

    location /foo {
        proxy_set_header X-Forwarded-Proto https;

        proxy_pass http://10.118.56.153:8001;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header Host $host;
        proxy_redirect off;
    }

    location /bar {
        proxy_set_header X-Forwarded-Proto https;

        proxy_pass http://10.118.56.153:8002;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header Host $host;
        proxy_redirect off;
    }
}
```

with a `location` section for each instance and where the `location` matches the SCRIPT_NAME and the port for `proxy_pass` matches REVERSE_PROXY_PORT in `.env`. 

Now do `docker compose up -d`.